### PR TITLE
Add help framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,14 @@
     <jacoco.missed.count>0</jacoco.missed.count>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.github.rvesse</groupId>
+      <artifactId>airline</artifactId>
+      <version>2.7.2</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -150,6 +158,32 @@
         <configuration>
           <argLine>@{argLine}</argLine>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.reaktivity.rym.internal.RymMain</mainClass>
+                  <manifestEntries>
+                    <Name>org/reaktivity/rym/</Name>
+                    <Specification-Title>${project.name}</Specification-Title>
+                    <Specification-Version>${project.version}</Specification-Version>
+                    <Specification-Vendor>reaktivity.org</Specification-Vendor>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/reaktivity/rym/internal/RymCli.java
+++ b/src/main/java/org/reaktivity/rym/internal/RymCli.java
@@ -24,8 +24,8 @@ import com.github.rvesse.airline.help.Help;
     commands = { Help.class })
 public final class RymCli
 {
-    // utility class
     private RymCli()
     {
+        // utility class
     }
 }

--- a/src/main/java/org/reaktivity/rym/internal/RymCli.java
+++ b/src/main/java/org/reaktivity/rym/internal/RymCli.java
@@ -15,19 +15,17 @@
  */
 package org.reaktivity.rym.internal;
 
-import com.github.rvesse.airline.Cli;
+import com.github.rvesse.airline.annotations.Cli;
+import com.github.rvesse.airline.help.Help;
 
-public final class RymMain
+@Cli(name = "rym",
+    description = "Reaktivity Management Tool",
+    defaultCommand = Help.class,
+    commands = { Help.class })
+public final class RymCli
 {
-    public static void main(
-        String[] args)
-    {
-        Cli<Runnable> parser = new Cli<>(RymCli.class);
-        parser.parse(args).run();
-    }
-
     // utility class
-    private RymMain()
+    private RymCli()
     {
     }
 }

--- a/src/main/java/org/reaktivity/rym/internal/RymMain.java
+++ b/src/main/java/org/reaktivity/rym/internal/RymMain.java
@@ -26,8 +26,8 @@ public final class RymMain
         parser.parse(args).run();
     }
 
-    // utility class
     private RymMain()
     {
+        // utility class
     }
 }

--- a/src/main/java/org/reaktivity/rym/internal/RymMain.java
+++ b/src/main/java/org/reaktivity/rym/internal/RymMain.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.rym.internal;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.github.rvesse.airline.annotations.Cli;
+import com.github.rvesse.airline.help.Help;
+import com.github.rvesse.airline.parser.errors.ParseCommandMissingException;
+import com.github.rvesse.airline.parser.errors.ParseCommandUnrecognizedException;
+
+@Cli(
+    name = "rym",
+    description = "Reaktivity Management Tool",
+    commands = { Help.class })
+public final class RymMain
+{
+
+    public static void main(String[] args)
+    {
+        com.github.rvesse.airline.Cli<Runnable> parser = new com.github.rvesse.airline.Cli<>(RymMain.class);
+
+        try
+        {
+            parser.parse(args).run();
+        }
+        catch (ParseCommandMissingException e)
+        {
+            showUsage(parser);
+        }
+        catch (ParseCommandUnrecognizedException e)
+        {
+            if (!args[0].equalsIgnoreCase("--help"))
+            {
+                System.err.format("%s\n\n", e.getMessage());
+            }
+            showUsage(parser);
+        }
+    }
+
+    private RymMain()
+    {
+    }
+
+    private static void showUsage(com.github.rvesse.airline.Cli<Runnable> parser)
+    {
+        try
+        {
+            Help.help(parser.getMetadata(), Arrays.asList());
+        }
+        catch (IOException e)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1

Output with no command:

```bash
$ java -jar target/rym-develop-SNAPSHOT.jar
usage: rym <command> [ <args> ]

Commands are:
    help   Display help information

See 'rym help <command>' for more information on a specific command.
```

Output with `help` command:

```bash
$ java -jar target/rym-develop-SNAPSHOT.jar help
usage: rym <command> [ <args> ]

Commands are:
    help   Display help information

See 'rym help <command>' for more information on a specific command.
```

Output with `--help` option:

```bash
$ java -jar target/rym-develop-SNAPSHOT.jar --help
usage: rym <command> [ <args> ]

Commands are:
    help   Display help information

See 'rym help <command>' for more information on a specific command.
```

Output with a command, `install`, which doesn't exist.
```bash
$ java -jar target/rym-develop-SNAPSHOT.jar install
Command 'install' not recognized

usage: rym <command> [ <args> ]

Commands are:
    help   Display help information

See 'rym help <command>' for more information on a specific command.
```